### PR TITLE
Add conda channels to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,7 @@
 name: coa
+channels:
+  - defaults
+  - conda-forge
 dependencies:
   - python=3.10
   - mamba=1.5.6


### PR DESCRIPTION
Some dependencies are not available through the default channel. This PR explicitly adds defaults and conda-forge to the environment file. 